### PR TITLE
Add dotenv for local environment variables

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,1 @@
+MONITORED_CERT_HOSTS="www.google.com, www.github.com"

--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@ Make sure you have [Node.js](http://nodejs.org/) and the [Heroku Toolbelt](https
 
 ```sh
 $ npm install
+$ cp .env.sample .env
 $ foreman s
 ```
 
-Environment variables
+Environment variables (may be set locally in `.env`)
 
 ```sh
 MONITORED_CERT_HOSTS="www.mysitethatsupportssl.com, www.othersitessl.com"
@@ -26,6 +27,7 @@ Your app should now be running on [localhost:5000](http://localhost:5000/).
 ```
 $ heroku create
 $ git push heroku master
+$ heroku config:set MONITORED_CERT_HOSTS="www.mysitethatsupportssl.com, www.othersitessl.com"
 $ heroku open
 ```
 or

--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 // Enable promise error logging
 require('promise/lib/rejection-tracking').enable();
 
+require('dotenv').config();
+
 var express = require('express');
 var app = express();
 var certificate = require('./src/certificate')

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test:watch": "npm run test -- --watch"
   },
   "dependencies": {
+    "dotenv": "^2.0.0",
     "ejs": "2.4.1",
     "express": "4.13.3",
     "promise": "^7.1.1"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/heroku/node-js-getting-started"
+    "url": "https://github.com/JensDebergh/certificate-dashboard"
   },
   "keywords": [
     "node",


### PR DESCRIPTION
To avoid polluting the local env vars, you can set project-specific vars in a `.env` file. This branch simply adds the `dotenv` module and loads the `.env` vars into the app.

The tests in `monitored_hosts_spec.js` cover necessary env var functionality, so no new tests were added. Please let me know if there is an edge case I didn't think of...

https://www.npmjs.com/package/dotenv
