### PR TITLE
Escape certificate info object

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Your app should now be running on [localhost:5000](http://localhost:5000/).
 ```
 $ heroku create
 $ git push heroku master
+$ heroku config:set MONITORED_CERT_HOSTS="www.mysitethatsupportssl.com, www.othersitessl.com"
 $ heroku open
 ```
 or

--- a/index.js
+++ b/index.js
@@ -13,8 +13,6 @@ app.set('views', __dirname + '/views');
 app.set('view engine', 'ejs');
 
 app.get('/', function(request, response) {
-  var promise = certificate.getCertificationData();
-
   certificate.getCertificationData().then(function(data) {
     responseData = {
       certInfo: JSON.stringify(data),

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/heroku/node-js-getting-started"
+    "url": "https://github.com/JensDebergh/certificate-dashboard"
   },
   "keywords": [
     "node",

--- a/views/pages/index.ejs
+++ b/views/pages/index.ejs
@@ -14,8 +14,8 @@
     <script src="./js/tls-dashboard/scripts.js" ></script>
   </head>
   <body>
-    <div id="container" class="container-fluid" data-certinfo='<%- certInfo %>'
-      data-rundate='<%= runDate %>'>
+    <div id="container" class="container-fluid" data-certinfo="<%= certInfo %>"
+      data-rundate="<%= runDate %>">
       <div class="row">
         <div class="col-xs-12 text-center bg-primary"><h1>TLS Certificate Expiration Dashboard</h1></div>
         <div class="col-xs-12 text-center bg-primary"><h3><small>Created: <span id="created_date"></span></small></h3></div>


### PR DESCRIPTION
Certificate authorities with apostrophes in their name (eg. Let's Encrypt) were producing invalid JSON due to not being properly escaped. The error in the console is:

`scripts.js:42 Uncaught TypeError: Cannot read property 'days_left' of undefined`

Escaping the output in the HTML allows this object to be properly parsed.

Fixes #2 
